### PR TITLE
Hotfix: Add type=int to port option

### DIFF
--- a/x11remote.py
+++ b/x11remote.py
@@ -9,8 +9,8 @@ from flask_sockets import Sockets
 
 def get_parser():
     parser = OptionParser(usage='%prog [-p|--port PORT] [-w|--websockets]')
-    parser.add_option('-p', '--port',
-            help='Port for X11Remote to listen on (default: %default)')
+    parser.add_option('-p', '--port', type=int,
+                  help='Port for X11Remote to listen on (default: %default)')
     parser.add_option('-w', '--websockets', action='store_true',
             help='Enable websocket support')
     parser.set_defaults(port=1234)


### PR DESCRIPTION
This pull request adds the `type=int` argument to the `--port` option in the parser. This ensures that the port value provided by the user is of type `int`.

![1](https://github.com/apirogov/x11remote/assets/4338559/6c5f29ec-afb8-4f02-a1b0-5d17364c8bcc)

Command to reproduce the error above: **python3 x11remote.py -p 5555**
